### PR TITLE
Adding separate date_format and time_format options

### DIFF
--- a/lib/time_splitter/accessors.rb
+++ b/lib/time_splitter/accessors.rb
@@ -1,7 +1,7 @@
 module TimeSplitter
   module Accessors
     def split_accessor(*attrs)
-      options = { format: "%F" }.merge!(attrs.extract_options!)
+      options = { date_format: "%F", time_format: "%R" }.merge!(attrs.extract_options!)
 
       attrs.each do |attr|
         # Maps the setter for #{attr}_time to accept multipart-parameters for Time
@@ -41,7 +41,7 @@ module TimeSplitter
 
         # Readers
         define_method("#{attr}_date") do
-          self.send(attr).try :strftime, options[:format]
+          self.send(attr).try :strftime, options[:date_format]
         end
 
         define_method("#{attr}_hour") do
@@ -53,7 +53,7 @@ module TimeSplitter
         end
 
         define_method("#{attr}_time") do
-          self.send(attr)
+          self.send(attr).try :strftime, options[:time_format]
         end
       end
     end

--- a/spec/time_splitter/accessors_spec.rb
+++ b/spec/time_splitter/accessors_spec.rb
@@ -56,9 +56,14 @@ describe TimeSplitter::Accessors do
           expect(model.starts_at_date).to be_nil
         end
 
-        it "lets you modify the format" do
-          Model.split_accessor(:starts_at, format: "%D")
+        it "lets you modify the date_format" do
+          Model.split_accessor(:starts_at, date_format: "%D")
           expect(model.starts_at_date).to be_nil
+        end
+
+        it "lets you modify the time_format" do
+          Model.split_accessor(:starts_at, time_format: "%I:%M%p")
+          expect(model.starts_at_time).to be_nil
         end
 
         it "sets the appropiate parts of #starts_at" do
@@ -134,9 +139,14 @@ describe TimeSplitter::Accessors do
           expect(model.starts_at_date).to eq "2222-12-22"
         end
 
-        it "lets you modify the format" do
-          Model.split_accessor(:starts_at, format: "%D")
+        it "lets you modify the date_format" do
+          Model.split_accessor(:starts_at, date_format: "%D")
           expect(model.starts_at_date).to eq "12/22/22"
+        end
+
+        it "lets you modify the time_format" do
+          Model.split_accessor(:starts_at, time_format: "%I:%M%p")
+          expect(model.starts_at_time).to eq "01:44PM"
         end
 
         it "sets the appropiate parts of #starts_at" do


### PR DESCRIPTION
First, thanks for working on this! Was just what I was looking for.

This pull request lets the time component be custom-formatted the same as the date component can be.

It also sets a default format for the time component. (perviously the default was to render the time component as `2012-12-12 12:12` - i.e it was including the date as well.
