### PR TITLE
Allow overriding date format method to override date setter

### DIFF
--- a/lib/time_splitter/accessors.rb
+++ b/lib/time_splitter/accessors.rb
@@ -39,7 +39,14 @@ module TimeSplitter
 
         define_method("#{attr}_time=") do |time|
           return unless time.present?
-          time = Time.parse(time) unless time.is_a?(Date) || time.is_a?(Time)
+
+          unless time.is_a?(Date) || time.is_a?(Time)
+            if options[:time_format]
+              time = Time.strptime(time, options[:time_format])
+            else
+              time = Time.parse(time)
+            end
+          end
           self.send("#{attr}=", self.send("#{attr}_or_new").change(hour: time.hour, min: time.min))
         end
 

--- a/lib/time_splitter/accessors.rb
+++ b/lib/time_splitter/accessors.rb
@@ -19,10 +19,12 @@ module TimeSplitter
 
         define_method("#{attr}_date=") do |date|
           return unless date.present?
-          if options[:date_format]
-            date = Date.strptime(date.to_s, options[:date_format])
-          else
-            date = Date.parse(date.to_s)
+          unless date.is_a?(Date) || date.is_a?(Time)
+            if options[:date_format]
+              date = Date.strptime(date.to_s, options[:date_format])
+            else
+              date = Date.parse(date.to_s)
+            end
           end
           self.send("#{attr}=", self.send("#{attr}_or_new").change(year: date.year, month: date.month, day: date.day))
         end

--- a/lib/time_splitter/accessors.rb
+++ b/lib/time_splitter/accessors.rb
@@ -19,7 +19,11 @@ module TimeSplitter
 
         define_method("#{attr}_date=") do |date|
           return unless date.present?
-          date = Date.parse(date.to_s)
+          if options[:date_format]
+            date = Date.strptime(date.to_s, options[:date_format])
+          else
+            date = Date.parse(date.to_s)
+          end
           self.send("#{attr}=", self.send("#{attr}_or_new").change(year: date.year, month: date.month, day: date.day))
         end
 

--- a/spec/time_splitter/accessors_spec.rb
+++ b/spec/time_splitter/accessors_spec.rb
@@ -77,6 +77,12 @@ describe TimeSplitter::Accessors do
           expect(model.starts_at).to eq Time.new(1111, 12, 31, 0, 0, 0, '+00:00')
         end
 
+        it "can set from a date when format is modified" do
+          Model.split_accessor(:starts_at, date_format: "%m-%d-%Y")
+          model.starts_at_date = Time.new(1111, 12, 31, 0, 0, 0, '+00:00')
+          expect(model.starts_at).to eq Time.new(1111, 12, 31, 0, 0, 0, '+00:00')
+        end
+
         it "is nil if the string is empty" do
           model.starts_at_date = ""
           expect(model.starts_at).to be_nil

--- a/spec/time_splitter/accessors_spec.rb
+++ b/spec/time_splitter/accessors_spec.rb
@@ -71,6 +71,12 @@ describe TimeSplitter::Accessors do
           expect(model.starts_at).to eq Time.new(1111, 1, 1, 0, 0, 0, '+00:00')
         end
 
+        it "can set from a string when format is modified" do
+          Model.split_accessor(:starts_at, date_format: "%m-%d-%Y")
+          model.starts_at_date = "12-31-1111"
+          expect(model.starts_at).to eq Time.new(1111, 12, 31, 0, 0, 0, '+00:00')
+        end
+
         it "is nil if the string is empty" do
           model.starts_at_date = ""
           expect(model.starts_at).to be_nil

--- a/spec/time_splitter/accessors_spec.rb
+++ b/spec/time_splitter/accessors_spec.rb
@@ -208,6 +208,12 @@ describe TimeSplitter::Accessors do
           expect(model.starts_at_time).to eq "01:44PM"
         end
 
+        it "can set from a string when format is modified" do
+          Model.split_accessor(:starts_at, time_format: "%k-%M")
+          model.starts_at_time = "23-59"
+          expect(model.starts_at).to eq Time.new(2222, 12, 22, 23, 59, 0, '+00:00')
+        end
+
         it 'sets the hour and minute of #starts_at' do
           model.starts_at_time = '08:33'
           expect(model.starts_at).to eq Time.new(2222, 12, 22, 8, 33, 0, '+00:00')


### PR DESCRIPTION
When passing the date_format option, I expected the date= method to parse using that format.  Instead DateTime.parse was used, which ignores the format.  Since I'm using a US-style mm-dd-yyyy ordering, this had the unexpected side-effect of switching my months with my days.

This pull request uses the #strptime method to parse if a date_format is passed, otherwise it continues to use the #parse method.