### PR TITLE
Add default method to model scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ rvm:
   - '2.0'
   - 1.9.3
 
+before_install:
+  - gem update bundler
+
 script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ split_accessor :starts_at, default: -> { DateTime.current }
 # => Thu, 10 Oct 2013 09:00:00 -0400 # DateTime
 ```
 
+You can even depend on another field for the default value.
+
+```ruby
+split_accessor :starts_at
+split_accessor :ends_at, default: -> { starts_at }
+
+# model = Model.new(starts_at: DateTime.current)
+# model.ends_at
+# => Thu, 10 Oct 2013 11:59:00 -0400 # DateTime
+```
+
 The default time object is `Time.new(0, 1, 1, 0, 0, 0, '+00:00')`.
 
 Note that TimeSplitter does not handle seconds at this time, and from testing it appears they are set to zero when modifying them.

--- a/lib/time_splitter/accessors.rb
+++ b/lib/time_splitter/accessors.rb
@@ -11,6 +11,7 @@ module TimeSplitter
         # This allows use of another property on default.
         # e.g. split_accessor :ends_at, default: -> { starts_at }
         define_method "#{attr}_default", options.fetch(:default, -> { Time.new(0, 1, 1, 0, 0, 0, "+00:00") })
+        private "#{attr}_default"
 
         # Default instance of the attribute, used if setting an element of the
         # time attribute before the attribute was sent. Allows us to retrieve a
@@ -19,6 +20,7 @@ module TimeSplitter
         define_method("#{attr}_or_new") do
           self.send(attr) || self.send("#{attr}_default")
         end
+        private "#{attr}_or_new"
 
         # Writers
 

--- a/lib/time_splitter/accessors.rb
+++ b/lib/time_splitter/accessors.rb
@@ -7,12 +7,17 @@ module TimeSplitter
         # Maps the setter for #{attr}_time to accept multipart-parameters for Time
         composed_of "#{attr}_time".to_sym, class_name: 'DateTime' if self.respond_to?(:composed_of)
 
+        # Adds the default method to object scope.
+        # This allows use of another property on default.
+        # e.g. split_accessor :ends_at, default: -> { starts_at }
+        define_method "#{attr}_default", options.fetch(:default, -> { Time.new(0, 1, 1, 0, 0, 0, "+00:00") })
+
         # Default instance of the attribute, used if setting an element of the
         # time attribute before the attribute was sent. Allows us to retrieve a
         # default value for +#{attr}+ to modify without explicitely overriding
         # the attr_reader. Defaults to a Time object with all fields set to 0.
         define_method("#{attr}_or_new") do
-          self.send(attr) || options.fetch(:default, ->{ Time.new(0, 1, 1, 0, 0, 0, "+00:00") }).call
+          self.send(attr) || self.send("#{attr}_default")
         end
 
         # Writers

--- a/lib/time_splitter/version.rb
+++ b/lib/time_splitter/version.rb
@@ -1,3 +1,3 @@
 module TimeSplitter
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/spec/time_splitter/accessors_spec.rb
+++ b/spec/time_splitter/accessors_spec.rb
@@ -231,5 +231,31 @@ describe TimeSplitter::Accessors do
         end
       end
     end
+
+    context 'when setting default time to another field' do
+      before do
+        class Model < ModelParent; attr_accessor :ends_at; end
+        Model.extend(TimeSplitter::Accessors)
+        Model.split_accessor(:starts_at, time_format: "%I:%M%p")
+        Model.split_accessor(:ends_at, default: -> { starts_at }, time_format: "%I:%M%p")
+      end
+
+      describe '#ends_at_date' do
+        it 'equals starts_at_date' do
+          model.starts_at    = DateTime.new(1111, 2, 3, 4, 5, 0, '+7')
+          model.ends_at_time = '06:59pm'
+          expect(model.ends_at_date).to eq model.starts_at_date
+        end
+      end
+
+      describe '#ends_at_time' do
+        it 'equals starts_at_time' do
+          model.starts_at    = DateTime.new(1111, 2, 3, 4, 5, 0, '+7')
+          model.ends_at_date = DateTime.new(2222, 2, 3).to_date
+          expect(model.ends_at_time).to eq model.starts_at_time
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Allows depend on another field for the `default` option.

This fix #8 
