### PR TITLE
Prevent commiting Gemfile.lock by ignoring it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Gemfile.lock
 *.gem
 *.rbc
 .bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ rvm:
   - '2.0'
   - 1.9.3
 
+before_install:
+  - gem update bundler
+
 script: bundle exec rspec spec


### PR DESCRIPTION
Since `Gemfile.lock` should not be versioned for Gems, I think it's better to ignore it.
